### PR TITLE
Remove the GOV.UK crown and font

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -2,8 +2,8 @@
 host: team-docs.design-system.service.gov.uk
 
 # Header-related options
-show_govuk_logo: true
-service_name: Design System team docs
+show_govuk_logo: false
+service_name: GOV.UK Design System team docs
 service_link: https://team-docs.design-system.service.gov.uk
 phase: Alpha
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,3 @@
+$govuk-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+
 @import "govuk_tech_docs";


### PR DESCRIPTION
Our team docs won’t be hosted on a service domain (at least not initially) so we should avoid using the logo or font.

Remove the logo (but add GOV.UK back to the name) and switch out the font.