### PR TITLE
Update canonical URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A reference guide for who we are and the way we do things. It's a playbook for a
 
 What's written here is the way we do things now, but that will change from time to time.
 
+View the playbook at https://govuk-design-system-team-docs.netlify.app/
+
 ## Technologies
 
 The docs were built using the [Tech Docs Template](https://github.com/alphagov/tech-docs-template), which uses [Tech Docs Gem version 3.3.1](https://github.com/alphagov/tech-docs-gem/releases/tag/v3.3.1).

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,10 +1,10 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: team-docs.design-system.service.gov.uk
+host: govuk-design-system-team-docs.netlify.app
 
 # Header-related options
 show_govuk_logo: false
 service_name: GOV.UK Design System team docs
-service_link: https://team-docs.design-system.service.gov.uk
+service_link: https://govuk-design-system-team-docs.netlify.app/
 phase: Alpha
 
 # Links to show on right-hand-side of header


### PR DESCRIPTION
Thanks to @36degrees adding Netlify to this repo, we can now view the playbook at https://govuk-design-system-team-docs.netlify.app/