### PR TITLE
Add note about Dependabot promoting some of our dependencies

### DIFF
--- a/source/how-we-work/version-control/pull-requests.html.md
+++ b/source/how-we-work/version-control/pull-requests.html.md
@@ -52,6 +52,8 @@ Be aware of [supply chain attacks](https://www.ncsc.gov.uk/collection/supply-cha
 
 If you want to check the changes being made to the dependency, use a tool like [Package Diff](https://diff.intrinsic.com/) which shows the difference between the published packages.
 
+A quick look at the `package-lock.json` file may reveal that Dependabot has incorrectly duplicated some `optionalDependencies` to `dependencies`. If it occurs, this can usually be fixed by checking out the branch, running `npm install` and pushing a new commit with the resulting `package-lock.json`.
+
 The PR should be reviewed by 2 developers if:
 
 - it's a major version bump or the release notes suggest there are breaking changes


### PR DESCRIPTION
Dependabot seems to easily promote some of our `devDependencies` to `dependencies` in `package-lock.json`. This usually happens for our dependencies listed as `optionalDependencies` and can be easily fixed. 

This PR documents the situation and the fix in our process for reviewing Dependabot PRs.

https://deploy-preview-37--govuk-design-system-team-docs.netlify.app/how-we-work/version-control/pull-requests#reviewing-a-pr-from-dependabot