### PR TITLE
Add contribution guide to index

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -10,3 +10,9 @@ weight: 1
 This is a reference guide for who we are and the way we do things. It's a playbook for anyone in the GOV.UK Design System team that tells us the 'right way' to do things. It's currently in alpha, meaning that contributions from the team are welcome and encouraged!
 
 What's written here is the way we do things now, but that will change from time to time.
+
+## Contribute to the playbook
+
+Contributions from the team are always welcome! This playbook is currently in alpha, meaning we're testing out what content and guidance is useful. Raising issues and pull requests is strongly encouraged, so that we can develop the playbook as a team.
+
+Follow the [contribution guide](https://github.com/alphagov/design-system-team-docs/blob/main/contributing.md) to add to our playbook.


### PR DESCRIPTION
This should make it easier for folks to find out how to add to the playbook, as we mostly link to the built version of the playbook rather than the repo.