### PR TITLE
Fix link in 'How we work' section

### DIFF
--- a/source/how-we-work/index.html.md
+++ b/source/how-we-work/index.html.md
@@ -8,5 +8,5 @@ weight: 4
 - [How to run a Design System team ceremony or workshop](./how-to-run-a-design-system-team-ceremony-or-workshop/)
 - [How to be an epic lead](./how-to-be-an-epic-lead/)
 - [Version Control](./version-control/)
-- [How to get help from other roles](./how-to-get-help-from-other-roles/)
+- [How to get help from other roles](./get-help-from-other-roles/)
   


### PR DESCRIPTION
Link to guide to get help from other roles was broken.