### PR TITLE
Add details of maintained products

### DIFF
--- a/source/guides/get-help-from-other-roles.html.md
+++ b/source/guides/get-help-from-other-roles.html.md
@@ -72,7 +72,7 @@ To get help
 
 A frontend developer designs, builds and improves website software that meets user needs. They write clean, accessible and open code, and are knowledgeable about fundamental frontend technologies such as HTML, CSS and JavaScript. You can read more about [frontend developers’](https://ddat-capability-framework.service.gov.uk/frontend-developer.html) skills on the DDaT Capability Framework.
 
-On the Design System team, frontend developers build and maintain [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/), the [Design System Website](https://github.com/alphagov/govuk-design-system) and the [rest of our product repositories](/what-we-do/#our-products).
+On the Design System team, frontend developers build and maintain [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/), the [Design System website](https://github.com/alphagov/govuk-design-system) and the [rest of our product repositories](/what-we-do/#our-products).
 
 You can ask a frontend developer for help with:
 

--- a/source/guides/get-help-from-other-roles.html.md
+++ b/source/guides/get-help-from-other-roles.html.md
@@ -83,8 +83,8 @@ You can ask a frontend developer for help with:
 - HTML, CSS and JavaScript
 - accessibility best practices
 - web performance
-- Setting up our projects and their tooling on your machine
-- Troubleshooting errors when running our projects (both on your machine and GitHub)
+- setting up our projects and their tooling on your machine
+- troubleshooting errors when running our projects (both on your machine and GitHub)
 
 To get help
 

--- a/source/guides/get-help-from-other-roles.html.md
+++ b/source/guides/get-help-from-other-roles.html.md
@@ -70,7 +70,7 @@ To get help
 
 ## Frontend developer
 
-A frontend developer designs, builds and improves website software that meets user needs. They write clean, accessible and open code, and are knowledgeable about fundamental frontend technologies such as HTML, CSS and JavaScript. You can read more about [frontend developers’](https://ddat-capability-framework.service.gov.uk/frontend-developer.html) skills on the DDaT Capability Framework.
+A frontend developer designs, builds and improves website software that meets user needs. They write clean, accessible and open code, and are knowledgeable about fundamental frontend technologies such as HTML, CSS and JavaScript. You can read more about [frontend developers’](https://ddat-capability-framework.service.gov.uk/frontend-developer.html) skills on the Government Digital and Data Profession Capability Framework.
 
 On the Design System team, frontend developers build and maintain [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/), the [Design System website](https://github.com/alphagov/govuk-design-system) and the [rest of our product repositories](/what-we-do/#our-products).
 

--- a/source/guides/get-help-from-other-roles.html.md
+++ b/source/guides/get-help-from-other-roles.html.md
@@ -24,7 +24,7 @@ You can use a few pieces of information to help other people understand, assess 
 
 ## Product and delivery managers
 
-A product manager is responsible for the quality of their products. They use their knowledge of user needs and business goals to frame problems and set priorities for delivery teams. A delivery manager is accountable for the delivery of products and services. You can read more about [product managers' skills](https://ddat-capability-framework.service.gov.uk/product-manager.html) and [deliver managers' skills](https://ddat-capability-framework.service.gov.uk/delivery-manager.html) on the Digital, Data and Technology (DDaT) Profession Capability Framework.
+A product manager is responsible for the quality of their products. They use their knowledge of user needs and business goals to frame problems and set priorities for delivery teams. A delivery manager is accountable for the delivery of products and services. You can read more about [product managers' skills](https://ddat-capability-framework.service.gov.uk/product-manager.html) and [deliver managers' skills](https://ddat-capability-framework.service.gov.uk/delivery-manager.html) on the Government Digital and Data Profession Capability Framework.
 
 You can ask a product manager and delivery manager for help with
 

--- a/source/guides/get-help-from-other-roles.html.md
+++ b/source/guides/get-help-from-other-roles.html.md
@@ -4,6 +4,7 @@ weight: 6
 last_reviewed_on: 2024-01-12
 review_in: 6 months
 ---
+
 # Get help from other roles
 
 We're a [multidisciplinary team](https://www.gov.uk/service-manual/service-standard/point-6-have-a-multidisciplinary-team) made up of people with a diverse mix of skills and expertise. This helps us make better quality decisions that lead to great outcomes for users, as opposed to working in siloes which isolate people from each other based on their role. Great ideas come from [combining different perspectives](https://gds.blog.gov.uk/2016/02/01/professions-and-boldness/).
@@ -14,7 +15,7 @@ If we ask people for help, [it's okay](https://govdesign.tumblr.com/post/1449096
 
 ## A basic template
 
-You can use a few pieces of information to help other people understand, assess and respond to your ask for help. 
+You can use a few pieces of information to help other people understand, assess and respond to your ask for help.
 
 - **Which role (or person) you need help from:** it's easy to glance past general requests for help when busy, so make it clear to the person or people you need help from.
 - **What you need:** describe what you might need someone to do and what their input helps unblock.
@@ -23,10 +24,10 @@ You can use a few pieces of information to help other people understand, assess 
 
 ## Product and delivery managers
 
-A product manager is responsible for the quality of their products. They use their knowledge of user needs and business goals to frame problems and set priorities for delivery teams. A delivery manager is accountable for the delivery of products and services. You can read more about [product managers' skills](https://ddat-capability-framework.service.gov.uk/product-manager.html) and [deliver managers' skills](https://ddat-capability-framework.service.gov.uk/delivery-manager.html) on the Digital, Data and Technology Profession Capability Framework.
+A product manager is responsible for the quality of their products. They use their knowledge of user needs and business goals to frame problems and set priorities for delivery teams. A delivery manager is accountable for the delivery of products and services. You can read more about [product managers' skills](https://ddat-capability-framework.service.gov.uk/product-manager.html) and [deliver managers' skills](https://ddat-capability-framework.service.gov.uk/delivery-manager.html) on the Digital, Data and Technology (DDaT) Profession Capability Framework.
 
 You can ask a product manager and delivery manager for help with
-  
+
 - making a decision
 - resolving a blocker
 - improving pace of delivery
@@ -38,10 +39,10 @@ You can ask a product manager and delivery manager for help with
 - escalating an issue
 
 To get help
-  
+
 - send a direct message on Slack
 - use a collaborative tool such as Padlet, Trello, Mural or Google Doc to frame your thoughts
-- arrange a call 
+- arrange a call
 
 You can see who is the current product or delivery manager on the '[Who we are](/who-we-are/)' page.
 
@@ -54,10 +55,10 @@ On this team, we tend not to focus on job titles and we work as a group instead.
 You can ask a designer for help with
 
 - understanding the problem you’re trying to solve
-- working with the team to advocate for users 
-- interpreting user research and data 
+- working with the team to advocate for users
+- interpreting user research and data
 - proposing potential solutions to your problem
-- making a prototype to test assumptions  
+- making a prototype to test assumptions
 - making sure the thing you’re working on is inclusive and accessible
 - visual design assistance on the thing you’re working on
 
@@ -65,4 +66,28 @@ To get help
 
 - send a message on Slack
 - use a collaborative tool such as Padlet, Trello, Mural or Google Doc to frame your thoughts
-- arrange a call 
+- arrange a call
+
+## Frontend developer
+
+A frontend developer designs, builds and improves website software that meets user needs. They write clean, accessible and open code, and are knowledgeable about fundamental frontend technologies such as HTML, CSS and JavaScript. You can read more about [frontend developers’](https://ddat-capability-framework.service.gov.uk/frontend-developer.html) skills on the DDaT Capability Framework.
+
+On the Design System team, frontend developers build and maintain [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/), the [Design System Website](https://github.com/alphagov/govuk-design-system) and the [rest of our product repositories](/what-we-do/#our-products).
+
+You can ask a frontend developer for help with:
+
+- using GitHub
+- investigating and implementing automation on GitHub
+- transforming designs into working HTML pages
+- the feasibility of designs when translated to code
+- HTML, CSS and JavaScript
+- accessibility best practices
+- web performance
+- Setting up our projects and their tooling on your machine
+- Troubleshooting errors when running our projects (both on your machine and GitHub)
+
+To get help
+
+- Post a message in #design-system-dev on Slack
+- Send a direct message on Slack
+- Arrange a call

--- a/source/support/products-we-support/index.html.md
+++ b/source/support/products-we-support/index.html.md
@@ -33,11 +33,30 @@ Security issues should be addressed, but only if they impact the services that u
 
 ### [GOV.UK Prototype Kit]
 
-As of May 2023, the Prototype team will handle any queries regarding the Kit. The Design System team can redirect Kit queries to the cross-gov slack channel #prototype-kit, or hand over queries either via the Prototype team Slack channel or via [email][GOV.UK Prototype Kit Email]
+The [GOV.UK Prototype Kit] is currently maintained by the GOV.UK Design System team. Huge thanks to the GOV.UK Prototype team, who’s hard work has made our job of maintaining the Prototype Kit much easier.
+
+We will:
+
+- update dependencies and address serious bugs
+- review bugs and dependencies every 3 months (serious bugs will be given high priority)
+
+We cannot:
+
+- provide user support on Slack, GitHub or via email
+- add new features
+- review contributions
+- update documentation
+- address smaller functionality issues that do not block usage
+
+Many departments told us about documentation and support for the Prototype Kit which was provided internally, so we encourage users to seek help from their colleagues.
 
 ### [Accessible Autocomplete]
 
-We’re not currently supporting the autocomplete repo
+The GOV.UK Design System team maintains the [Accessible Autocomplete] as a standalone component. However, we’re only able to put in minimal work to support it.
+
+[Read about our plans to maintain this component](https://github.com/alphagov/accessible-autocomplete/issues/532).
+
+[Read more about the types of support we can provide](https://github.com/alphagov/accessible-autocomplete/issues/430).
 
 [Accessible Autocomplete]: https://github.com/alphagov/accessible-autocomplete
 [Community backlog]: https://design-system.service.gov.uk/community/backlog/
@@ -48,4 +67,3 @@ We’re not currently supporting the autocomplete repo
 [GOV.UK Prototype Kit]: https://govuk-prototype-kit.herokuapp.com/docs
 [GOV.UK Prototype Kit Email]: govuk-prototype-kit-support@digital.cabinet-office.gov.uk
 [GOV.UK Template]: http://alphagov.github.io/govuk_template/
-

--- a/source/what-we-do/index.html.md.erb
+++ b/source/what-we-do/index.html.md.erb
@@ -9,7 +9,7 @@ We maintain the GOV.UK Design System and related tools.
 
 ## Our products
 
-### Actively maintained
+### Actively developed
 
 - [GOV.UK Design System Website] - guidance for making government services consistent with GOV.UK. The code is maintained in the [govuk-design-system GitHub repository].
 - [GOV.UK Frontend] - a code library of GOV.UK Design System components.
@@ -17,19 +17,40 @@ We maintain the GOV.UK Design System and related tools.
 - [Community backlog] - a backlog of user-submitted component and pattern suggestions for inclusion into the Design System.
 - [stylelint-config-gds] - a stylelint configuration for SCSS and CSS files across GDS.
 
-### Security patches only
+### Maintenance
 
-- [Accessible Autocomplete] - a component that helps users choose answers from a provided list
+#### Accessible Autocomplete
+
+The GOV.UK Design System team maintains the [Accessible Autocomplete] as a standalone component. However, we’re only able to put in minimal work to support it.
+
+[Read about our plans to maintain this component](https://github.com/alphagov/accessible-autocomplete/issues/532).
+
+[Read more about the types of support we can provide](https://github.com/alphagov/accessible-autocomplete/issues/430).
+
+#### GOV.UK Prototype Kit
+
+The [GOV.UK Prototype Kit] is currently maintained by the GOV.UK Design System team. Huge thanks to the GOV.UK Prototype team, who’s hard work has made our job of maintaining the Prototype Kit much easier.
+
+We will:
+
+- update dependencies and address serious bugs
+- review bugs and dependencies every 3 months (serious bugs will be given high priority)
+
+We cannot:
+
+- provide user support on Slack, GitHub or via email
+- add new features
+- review contributions
+- update documentation
+- address smaller functionality issues that do not block usage
+
+Many departments told us about documentation and support for the Prototype Kit which was provided internally, so we encourage users to seek help from their colleagues.
 
 ### Legacy products
 
 - [GOV.UK Elements]
 - [GOV.UK Frontend Toolkit]
 - [GOV.UK Template]
-
-### No longer supported
-
-- [GOV.UK Prototype Kit] - The GOV.UK Prototype Kit team is responsible for maintenance and support.
 
 [Accessible Autocomplete]: https://github.com/alphagov/accessible-autocomplete
 [Community backlog]: https://design-system.service.gov.uk/community/backlog/

--- a/source/what-we-do/index.html.md.erb
+++ b/source/what-we-do/index.html.md.erb
@@ -4,3 +4,43 @@ weight: 3
 ---
 
 # What we do
+
+We maintain the GOV.UK Design System and related tools.
+
+## Our products
+
+### Actively maintained
+
+- [GOV.UK Design System Website] - guidance for making government services consistent with GOV.UK. The code is maintained in the [govuk-design-system GitHub repository].
+- [GOV.UK Frontend] - a code library of GOV.UK Design System components.
+- [GOV.UK Frontend Docs] - Technical documentation for installing and using GOV.UK Frontend. The code is maintained in the [govuk-frontend-docs GitHub repository].
+- [Community backlog] - a backlog of user-submitted component and pattern suggestions for inclusion into the Design System.
+- [stylelint-config-gds] - a stylelint configuration for SCSS and CSS files across GDS.
+
+### Security patches only
+
+- [Accessible Autocomplete] - a component that helps users choose answers from a provided list
+
+### Legacy products
+
+- [GOV.UK Elements]
+- [GOV.UK Frontend Toolkit]
+- [GOV.UK Template]
+
+### No longer supported
+
+- [GOV.UK Prototype Kit] - The GOV.UK Prototype Kit team is responsible for maintenance and support.
+
+[Accessible Autocomplete]: https://github.com/alphagov/accessible-autocomplete
+[Community backlog]: https://design-system.service.gov.uk/community/backlog/
+[GOV.UK Design System website]: https://design-system.service.gov.uk/
+[govuk-design-system GitHub repository]: https://github.com/alphagov/govuk-design-system
+[GOV.UK Elements]: http://govuk-elements.herokuapp.com/
+[GOV.UK Frontend]: https://github.com/alphagov/govuk-frontend
+[GOV.UK Frontend Docs]: https://frontend.design-system.service.gov.uk/
+[govuk-frontend-docs GitHub repository]: https://github.com/alphagov/govuk-frontend-docs
+[GOV.UK Frontend Toolkit]: https://github.com/alphagov/govuk_frontend_toolkit
+[GOV.UK Prototype Kit]: https://govuk-prototype-kit.herokuapp.com/docs
+[GOV.UK Prototype Kit Email]: govuk-prototype-kit-support@digital.cabinet-office.gov.uk
+[GOV.UK Template]: http://alphagov.github.io/govuk_template/
+[stylelint-config-gds]: https://github.com/alphagov/stylelint-config-gds

--- a/source/what-we-do/index.html.md.erb
+++ b/source/what-we-do/index.html.md.erb
@@ -5,7 +5,7 @@ weight: 3
 
 # What we do
 
-We maintain the GOV.UK Design System and related tools.
+We maintain the GOV.UK Design System and related tools. For guidance on supporting our products, see [Products we support](/support/products-we-support/).
 
 ## Our products
 
@@ -19,32 +19,8 @@ We maintain the GOV.UK Design System and related tools.
 
 ### Maintenance
 
-#### Accessible Autocomplete
-
-The GOV.UK Design System team maintains the [Accessible Autocomplete] as a standalone component. However, we’re only able to put in minimal work to support it.
-
-[Read about our plans to maintain this component](https://github.com/alphagov/accessible-autocomplete/issues/532).
-
-[Read more about the types of support we can provide](https://github.com/alphagov/accessible-autocomplete/issues/430).
-
-#### GOV.UK Prototype Kit
-
-The [GOV.UK Prototype Kit] is currently maintained by the GOV.UK Design System team. Huge thanks to the GOV.UK Prototype team, who’s hard work has made our job of maintaining the Prototype Kit much easier.
-
-We will:
-
-- update dependencies and address serious bugs
-- review bugs and dependencies every 3 months (serious bugs will be given high priority)
-
-We cannot:
-
-- provide user support on Slack, GitHub or via email
-- add new features
-- review contributions
-- update documentation
-- address smaller functionality issues that do not block usage
-
-Many departments told us about documentation and support for the Prototype Kit which was provided internally, so we encourage users to seek help from their colleagues.
+- [Accessible Autocomplete] - a standalone component that helps users choose answers from a provided list.
+- [GOV.UK Prototype Kit] - a tool to quickly make interactive, accessible and realistic prototypes of GOV.UK services.
 
 ### Legacy products
 


### PR DESCRIPTION
For the "get help with a frontend developer" content, I realised it would be helpful to have a page listing the products we support, so this is that!

[#69b02c6](https://github.com/alphagov/design-system-team-docs/pull/49/commits/69b02c6082e6628b359ce287eb7a2d0eaa9ad989) is the relevant commit. The rest are the aforementioned "get help" docs that have been merged.