### PR TITLE
Add roles and responsibilities

### DIFF
--- a/source/guides/index.html.md
+++ b/source/guides/index.html.md
@@ -1,6 +1,6 @@
 ---
 title: Guides
-weight: 4
+weight: 5
 ---
 
 # Guides

--- a/source/how-we-work/contribution-model.html.md.erb
+++ b/source/how-we-work/contribution-model.html.md.erb
@@ -1,0 +1,30 @@
+---
+title: Contribution model
+weight: 9
+last_reviewed_on: 2023-12-21
+review_in: 6 months
+---
+
+# Contribution model
+
+The GOV.UK Design System was originally built on a culture of cross-government collaboration, and since early on the Design System has been [open to contributions](https://designnotes.blog.gov.uk/2018/09/26/opening-up-the-gov-uk-design-system-for-contributions/). Over the years we've learned a lot about how to make this work well, and we [iterated the contribution model](https://designnotes.blog.gov.uk/2023/05/31/iterating-the-gov-uk-design-system-contribution-model/) in 2023. 
+
+This forms the basis of our product operating model: how we combine experience and perspectives from across government to deliver a useful, usable, consistent and versatile design system for service teams across government.
+
+> There is no one-size-fits-all process for how we work. The contribution model is process agnostic, and there are many processes that could happen to create value at different stages of the model.
+
+You can see the model and the activities we do at each stage [in a spreadsheet](https://docs.google.com/spreadsheets/d/1jSGZWy2IO0cZvyggyaa5pz2-6L5bPg7FXXxbJZbTDjA/edit#gid=0) or watch the video that describes the model. The model shows team members what stages we work through, who does what at each stage, and what's expected of them.
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/iLdjczbYBCc?si=A2qLbhRJruogdXwA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+## Roles and responsibilities
+
+We work in a multidisciplinary way. Many people contribute to the work happening across the stages of the contribution model, but some people have a clear role and responsibility to drive things forward. We also rely on each other to provide the necessary inputs at each stage.
+
+For example, a designer will consolidate multiple designs to define a versatile style, component or pattern. Designers need evidence as source material for that, which they may get from the user researcher. 
+
+When not playing a driving role, people play either 
+- a supporting role, contributing to work at this stage, or 
+- need awareness of what's happening, so they can have input later.
+
+<!--- Go on to explain the different roles and responsibilities from the spreadsheet. --->

--- a/source/how-we-work/contribution-model.html.md.erb
+++ b/source/how-we-work/contribution-model.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 The GOV.UK Design System was originally built on a culture of cross-government collaboration, and since early on the Design System has been [open to contributions](https://designnotes.blog.gov.uk/2018/09/26/opening-up-the-gov-uk-design-system-for-contributions/). Over the years we've learned a lot about how to make this work well, and we [iterated the contribution model](https://designnotes.blog.gov.uk/2023/05/31/iterating-the-gov-uk-design-system-contribution-model/) in 2023. 
 
-This forms the basis of our product operating model: how we combine experience and perspectives from across government to deliver a useful, usable, consistent and versatile design system for service teams across government.
+This forms the basis of our product operating model: how we combine evidence and perspectives from across government to deliver a useful, usable, consistent and versatile design system for service teams across government.
 
 > There is no one-size-fits-all process for how we work. The contribution model is process agnostic, and there are many processes that could happen to create value at different stages of the model.
 
@@ -27,4 +27,58 @@ When not playing a driving role, people play either
 - a supporting role, contributing to work at this stage, or 
 - need awareness of what's happening, so they can have input later.
 
-<!--- Go on to explain the different roles and responsibilities from the spreadsheet. --->
+The team collaborated on defining roles and responsibilities in a workshop during 2023. [This spreadsheet](https://docs.google.com/spreadsheets/d/1heSU7EGuE73V3HLiqeBEs9Yk0UP_bu-U0Egx4bSNySA/edit?pli=1#gid=0) shows the results.
+
+### Prioritise what to work on
+
+The product manager, lead developer and lead designer play a driving role. The delivery manager, user researcher and community designer play a supporting role.
+
+The product manager requires good-enough data to make realistic calls on what's valuable, and input from delivery, design and development to understand what's feasible.
+
+### Gather evidence
+
+The user researcher, community designer, developer and designer play a driving role in gathering evidence. The product manager, accessibility specialist and content designer play a supporting role.
+
+The designer and developer need examples from the community, which the community designer and user researcher help facilitate.
+
+### Consolidate designs
+
+The designer and developer play a driving role. The accessibility specialist, community designer and product manager play a supporting role. 
+
+The designer and developer need to know the design direction or rationale for any constraints.
+
+### Scope to something deliverable
+
+The product manager and delivery manager play a driving role. Everyone else plays a supporting role.
+
+The product manager and delivery manager need to know the major risks or uncertainties that need exploring and the extent of possible variations.
+
+### Create a rough proposal
+
+The designer and developer play a driving role. The accessibility specialist, content designer and product manager play a supporting role.
+
+The developer and designer need someone to communicate with the working group to let them know about the upcoming proposal.
+
+### Build a working version of the thing
+
+The designer, developer and accessibility specialist play a driving role. The content designer and technical writer play a supporting role.
+
+This is a highly collaborative stage of the model. 
+
+### Do more user research (only if needed)
+
+The user researcher plays a driving role. The accessibility specialist, community designer and product manager play a supporting role.
+
+The user researcher needs information from the designer and developer in order decide whether research is necessary.
+
+### Build a robust version of the thing
+
+The accessibility specialist, content designer, delivery manager, designer, developer, technical writer and user researcher play a driving role. 
+
+This is a highly collaborative stage of the model. 
+
+### Publish
+
+The community designer, content designers, developer and technical writer play a driving role. The delivery manager, product manager, lead developer and lead designer play a supporting role.
+
+The content designer needs a plan and expected audience for communicating the publication.


### PR DESCRIPTION
In one-to-one sessions with team members, our coach identified that people needed more clarity on their role in the team.

Specifically:
- What is expected of me in my role?
- What should or shouldn’t I get involved in?
- When should I get involved?

The team reviewed the [capability framework](https://ddat-capability-framework.service.gov.uk/) for their role to get a general overview. We then mapped what each role contributes to new elements in our contribution model, and what each role needed from others on the team to be successful. 

This pull request makes those roles and responsibilities a part of our playbook.