### PR TITLE
Suggested updates to support guidance 

### DIFF
--- a/source/support/communicating-with-users/common-responses.html.md
+++ b/source/support/communicating-with-users/common-responses.html.md
@@ -86,6 +86,12 @@ Redirect: govuk-enquiries@digital.cabinet-office.gov.uk
 
 Point the user to the [GDS Request a thing] page.
 
+### Emails or queries for government or Downing Street
+
+We have no influence over government policy and are unable to redirect emails to anyone who does. 
+
+Emails offering feedback or suggestions on government policy or politicians should be closed as spam.
+
 ## Latest release questions
 
 ### Browser support changes in GOV.UK Frontend v5
@@ -476,12 +482,11 @@ There is some guidance here about services for government users: <https://www.go
 
 Also, Amy Hupe who used to work on the GOV.UK Design System wrote about internal services and design systems: <https://amyhupe.co.uk/articles/why-you-dont-need-a-separate-design-system-for-internal-services/> 
 
-
 We do encourage teams building internal tools to make use of the GOV.UK Design System where it's appropriate for their use case. You should test your application with real users which will help you determine if you're building your application in a way that ensures users can complete their tasks and whether you need to make any adjustments to meet user needs.
 
 We also have an open issue in our backlog about making it easier to create admin systems, case working tools and intranets using the GOV.UK Design System: <https://github.com/alphagov/govuk-design-system-backlog/issues/185>. Feel free to leave any comments about your use case on the issue. Very much related to the above issue, we also have an open issue around changing the default font and colours which you might find helpful: <https://github.com/alphagov/govuk-design-system/issues/1019>
 
-Alos, departmental design systems often document patterns used for ‘admin’ or ‘internal’ services. Some to look at:
+Also, departmental design systems often document patterns used for ‘admin’ or ‘internal’ services. Some to look at:
 <https://moj-design-system.herokuapp.com/>
 <https://design.homeoffice.gov.uk/>
 <https://design.tax.service.gov.uk/>
@@ -507,6 +512,16 @@ Some caseworking design patterns from when Chris from Home Office used to  run a
 >https://www.gov.uk/report-suspicious-emails-websites-phishing
 >
 >As for this repo, unfortunately if people want to run a scam, it's already fairly easy to copy and paste code from any website in order to impersonate it.
+
+### Marketing emails or other spam not requiring a response
+
+If an email contains unsolicited marketing or incomprehensible nonsense:
+
+- Set [Design System] Primary to “Spam”
+- Set [Design System] Secondary to “None of the Above”
+- Click the "Apply macro" button, select "Design System" and then "close with no reply"
+- Include internal note if appropriate
+- “Submit as solved”
 
 ## Website
 

--- a/source/support/products-we-support/index.html.md
+++ b/source/support/products-we-support/index.html.md
@@ -33,11 +33,13 @@ Security issues should be addressed, but only if they impact the services that u
 
 ### [GOV.UK Prototype Kit]
 
-As of May 2023, the Prototype team will handle any queries regarding the Kit. The Design System team can redirect Kit queries to the cross-gov slack channel #prototype-kit, or hand over queries either via the Prototype team Slack channel or via [email][GOV.UK Prototype Kit Email]
+As of December 2023, the Prototype Kit is in maintenance mode and the Prototype Kit team has been disbanded. The Design System team has taken stewardship of the Kit for maintenance purposes but does not provide end-user support.
+
+Kit queries should be redirected to the cross-gov slack channel #prototype-kit.
 
 ### [Accessible Autocomplete]
 
-We’re not currently supporting the autocomplete repo
+We’re not currently supporting the autocomplete repo.
 
 [Accessible Autocomplete]: https://github.com/alphagov/accessible-autocomplete
 [Community backlog]: https://design-system.service.gov.uk/community/backlog/
@@ -46,6 +48,4 @@ We’re not currently supporting the autocomplete repo
 [GOV.UK Frontend]: https://github.com/alphagov/govuk-frontend
 [GOV.UK Frontend Toolkit]: https://github.com/alphagov/govuk_frontend_toolkit
 [GOV.UK Prototype Kit]: https://govuk-prototype-kit.herokuapp.com/docs
-[GOV.UK Prototype Kit Email]: govuk-prototype-kit-support@digital.cabinet-office.gov.uk
 [GOV.UK Template]: http://alphagov.github.io/govuk_template/
-


### PR DESCRIPTION
Random assortment of possible changes for support docs:

- Updates to the Prototype Kit section indicating that no end-user support is currently offered.
- How to treat emails that are directed at the government (e.g. policy suggestions, criticisms of ministers, etc.)
- How to categorise and resolve spam emails without generating an automatic response.
- Some spelling and formatting corrections I noticed along the way.