### PR TITLE
Add leadership group documentation

### DIFF
--- a/source/who-we-are/index.html.md.erb
+++ b/source/who-we-are/index.html.md.erb
@@ -4,3 +4,4 @@ weight: 2
 ---
 
 # Who we are
+[Leadership group](./leadership-group/)

--- a/source/who-we-are/leadership-group.html.md
+++ b/source/who-we-are/leadership-group.html.md
@@ -1,0 +1,48 @@
+---
+title: GOV.UK Design System leadership group
+weight: 5
+---
+
+# Leadership group
+
+The GOV.UK Design System leadership group is responsible for doing the work that makes the work, work.
+
+## Who we are
+- Chris Ballantine-Thomas (Senior Interaction Designer)
+- Kelly Lee (Senior Delivery Manager)
+- Oliver Byford (Lead Frontend Developer)
+- Steve Messer (Senior Product Manager)
+
+## What we do
+- evolve and adapt the team’s strategic direction
+- iterate our business model and economic case
+- prioritise work and build a delivery roadmap
+- ensure technical decisions align with the team and wider GDS principles and vision
+- keep up to date with new technologies and features
+- iterate ways of working and coach the team to deliver at pace
+- facilitate the best makeup of the team and lead on recruitment
+- report and respond to ad hoc requests from senior leadership
+- set and monitor the team’s budget and costs
+- procure tooling and resources needed by the team
+- manage, mitigate and escalate risks and issues which cannot be resolved within the team
+- ensure technical debt and bugs are properly tracked
+- hold 121s with team members
+
+## How we work
+The team leads use a [Kanban board](https://github.com/orgs/alphagov/projects/87/views/1) to track their work. The group meets each Monday morning to discuss priorities for the week ahead.
+
+## Leadership charter
+1. Role model the team’s charter
+2. Be visible to the team
+3. Be accountable for our decisions, and keep the team accountable for the work
+4. Advocate for our team, internally and externally
+5. Champion inclusive culture, uphold psychological safety and ensure our ways of working promote this
+6. Regularly seek and give feedback from the team. Show gratitude and recognise excellence
+7. Help team members do their best work. Step in when they’re not, but with kindness and understanding
+8. Have conversations openly when possible. Communicate clearly and often
+9. Help shape the team’s strategic direction
+10. Support other leads when need arises. Own shared issues
+11. Proactively spot issues and initiate action
+12. Respectfully challenge decisions, even when difficult. Commit once a decision has been made, whatever the outcome
+13. Make decisions only when others can’t
+14. Look sideways. Align with GDS standards where appropriate and look for opportunities to collaborate


### PR DESCRIPTION
Includes information on who is in the group, what the group does, and the agreed leadership charter.