### PR TITLE
Clarify name and status

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,9 +3,9 @@ host: govuk-design-system-team-docs.netlify.app
 
 # Header-related options
 show_govuk_logo: false
-service_name: GOV.UK Design System team docs
-service_link: https://govuk-design-system-team-docs.netlify.app/
-phase: Alpha
+service_name: GOV.UK Design System team playbook
+service_link: /
+phase: Internal
 
 # Links to show on right-hand-side of header
 header_links:

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 1
 
 # About these docs
 
-<%= warning_text('This is a prototype.') %>
+<%= warning_text('This is for internal use by the Design System team. Public-facing documentation can be found at <a href="https://design-system.service.gov.uk">design-system.service.gov.uk</a>.') %>
 
-This is a reference guide for who we are and the way we do things. It's a playbook for anyone in the GOV.UK Design System team that tells us the 'right way' to do things. It's currently in alpha, meaning that contributions from the team are welcome and encouraged!
+This is a reference guide for who we are and the way we do things. It's a playbook for anyone in the GOV.UK Design System team that tells us the 'right way' to do things.
 
 What's written here is the way we do things now, but that will change from time to time.
 
 ## Contribute to the playbook
 
-Contributions from the team are always welcome! This playbook is currently in alpha, meaning we're testing out what content and guidance is useful. Raising issues and pull requests is strongly encouraged, so that we can develop the playbook as a team.
+Contributions from anyone on the team are welcome and encouraged! This playbook is currently in its early stages of development, and we're still testing out what content and guidance is useful.
 
 Follow the [contribution guide](https://github.com/alphagov/design-system-team-docs/blob/main/contributing.md) to add to our playbook.


### PR DESCRIPTION
Prioritise describing the playbook as ‘internal’ over being in ‘alpha’, and consistently use the word ‘playbook’ rather than ‘manual’ in the header.