### PR TITLE
Enable ‘pretty URLs’ when running locally

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,6 @@
 require 'govuk_tech_docs'
 
 GovukTechDocs.configure(self)
+
+# Enable 'pretty URLs' (rewrites e.g. /foo.html to /foo/index.html)
+activate :directory_indexes


### PR DESCRIPTION
Pretty URLs are when files are rewritten to directories so that you don’t see the file extension. For example, `foo.html` would be rewritten to `/foo/index.html` so that you can access it at `/foo/`.

Netlify is currently configured to [rewrite ‘pretty URLs’ as part of post-processing when building the site][1] but this isn’t currently happening when running locally using `bundle exec middleman serve`.

This means that links that work when the site is deployed don’t work locally. For example, a relative link `./core-values/` from `/how-we-work` fails because the page is at `how-we-work/core-values.html`.

Thankfully, [Middleman has this functionality built in][2] so it’s just a case of enabling it.

Once this has merged, we may want to disable Netlify’s post-processing of pretty URLs to ensure that the behaviour is consistent with the local development environment.

[1]: https://docs.netlify.com/site-deploys/post-processing/?_gl=1%2asir73t%2a_gcl_au%2aMTU4OTY2NTQ2MS4xNjk4MjM5OTU2
[2]: https://middlemanapp.com/advanced/pretty-urls/