### PR TITLE
Add a heading to make it easier to view the model

### DIFF
--- a/source/how-we-work/contribution-model.html.md.erb
+++ b/source/how-we-work/contribution-model.html.md.erb
@@ -13,6 +13,8 @@ This forms the basis of our product operating model: how we combine evidence and
 
 > There is no one-size-fits-all process for how we work. The contribution model is process agnostic, and there are many processes that could happen to create value at different stages of the model.
 
+## View the model
+
 You can see the model and the activities we do at each stage [in a spreadsheet](https://docs.google.com/spreadsheets/d/1jSGZWy2IO0cZvyggyaa5pz2-6L5bPg7FXXxbJZbTDjA/edit#gid=0) or watch the video that describes the model. The model shows team members what stages we work through, who does what at each stage, and what's expected of them.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/iLdjczbYBCc?si=A2qLbhRJruogdXwA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
Some epics will cover a stage of the contribution model, and in those scenarios people might want to look at and review the model – to see what activities might happen and who gets involved.

This PR adds a heading to make that easier and give us a link we can share.