### PR TITLE
Add code of conduct for workshops

### DIFF
--- a/source/community/code-of-conduct-for-workshops.html.md
+++ b/source/community/code-of-conduct-for-workshops.html.md
@@ -1,0 +1,37 @@
+---
+title: How to use GitHub to visualise your work
+weight: 5
+---
+
+# Code of conduct for workshops
+
+The following code of conduct applies to all publicly-available events, workshops and webinars run by the GOV.UK Design System team.
+
+In virtual spaces, the code of conduct applies to main rooms, breakout rooms and all resource documents.
+
+**1. Respect others**
+Have respect for all fellow participants. We should all create a harassment-free event for everyone regardless of gender, age, sexual identity, disability, physical appearance, body size, race, ethnicity, technical skill level, economic standing, religion or belief. Harassment will not be tolerated in any form.
+
+**2. Communicate flexibly**
+Expect people to prefer different ways of communicating on a video conference, such as turning off their video or using chat instead of speaking.
+
+**3. Welcome others**
+Help create a safe and welcoming environment. We can do this by being open to diverse points of view, by inviting other people to join and by keeping things people share confidential if they specify it.
+
+**4. Share context**
+Do not assume everyone has the same context. Encourage questions.
+
+**5. Listen actively**
+Listen to others, and ensure that all activities are respectful, participatory, and productive.
+
+**6. Respond constructively**
+Provide constructive, helpful feedback rather than criticising.
+
+**7. Maintain privacy**
+Attendees should not record video or take photographs of sessions run unless specified by session runners. You can take screenshots of presentation slides for personal use or shared within a government context unless stated otherwise by the session runners.
+
+**8. Share responsibly**
+Be considerate of what you share on social media. Do not share any content, insights or links from sessions without the explicit permission of the session runners.
+
+**9. Uphold conduct**
+The event organisers reserve the right to ask anyone in violation of these policies to not participate in further activities. Organisers will reinforce this code throughout event engagements. If you have any concerns, please contact any of our organisers immediately.

--- a/source/community/code-of-conduct-for-workshops.html.md
+++ b/source/community/code-of-conduct-for-workshops.html.md
@@ -42,4 +42,5 @@ Attendees should not record video or take photographs of sessions run unless spe
 Be considerate of what you share on social media. Do not share any content, insights or links from sessions without the explicit permission of the session runners.
 
 **9. Uphold conduct**
+
 The event organisers reserve the right to ask anyone in violation of these policies to not participate in further activities. Organisers will reinforce this code throughout event engagements. If you have any concerns, please contact any of our organisers immediately.

--- a/source/community/code-of-conduct-for-workshops.html.md
+++ b/source/community/code-of-conduct-for-workshops.html.md
@@ -10,27 +10,35 @@ The following code of conduct applies to all publicly-available events, workshop
 In virtual spaces, the code of conduct applies to main rooms, breakout rooms and all resource documents.
 
 **1. Respect others**
+
 Have respect for all fellow participants. We should all create a harassment-free event for everyone regardless of gender, age, sexual identity, disability, physical appearance, body size, race, ethnicity, technical skill level, economic standing, religion or belief. Harassment will not be tolerated in any form.
 
 **2. Communicate flexibly**
+
 Expect people to prefer different ways of communicating on a video conference, such as turning off their video or using chat instead of speaking.
 
 **3. Welcome others**
+
 Help create a safe and welcoming environment. We can do this by being open to diverse points of view, by inviting other people to join and by keeping things people share confidential if they specify it.
 
 **4. Share context**
+
 Do not assume everyone has the same context. Encourage questions.
 
 **5. Listen actively**
+
 Listen to others, and ensure that all activities are respectful, participatory, and productive.
 
 **6. Respond constructively**
+
 Provide constructive, helpful feedback rather than criticising.
 
 **7. Maintain privacy**
+
 Attendees should not record video or take photographs of sessions run unless specified by session runners. You can take screenshots of presentation slides for personal use or shared within a government context unless stated otherwise by the session runners.
 
 **8. Share responsibly**
+
 Be considerate of what you share on social media. Do not share any content, insights or links from sessions without the explicit permission of the session runners.
 
 **9. Uphold conduct**

--- a/source/community/index.html.md.erb
+++ b/source/community/index.html.md.erb
@@ -4,3 +4,5 @@ weight: 10
 ---
 
 # Community
+
+- [Code of conduct for workshops](./code-of-conduct-for-workshops/)


### PR DESCRIPTION
This is currently a Google doc on our drive. Having a web version makes it easier to access for workshop attendees