### PR TITLE
Update team page on team playbook

### DIFF
--- a/source/who-we-are/index.html.md.erb
+++ b/source/who-we-are/index.html.md.erb
@@ -4,4 +4,4 @@ weight: 2
 ---
 
 # Who we are
-You can see the full list of team members [here on the website](https://design-system.service.gov.uk/design-system-team/).
+You can [see the full list of team members](https://design-system.service.gov.uk/design-system-team/) on the website.

--- a/source/who-we-are/index.html.md.erb
+++ b/source/who-we-are/index.html.md.erb
@@ -4,23 +4,4 @@ weight: 2
 ---
 
 # Who we are
-[Leadership group](./leadership-group/)
-
-- Anika Henke – Senior Accessibility Specialist
-- Brett Kyle – Senior Frontend Developer
-- Calvin Lau – Senior Content Designer
-- Charlotte Downs – Interaction Designer
-- Ciandelle Hughes – Interaction Designer
-- Claire Ashworth – Technical Writer
-- Imran Hussain – Community Designer
-- Izabela Podralska – Delivery Manager
-- Kam Nijjar – Associate Delivery Manager
-- Katrina Birch – User Researcher
-- Kelly Lee – Senior Delivery Manager
-- Kim 'beeps' Grey – Frontend Developer
-- Mia Allers – Senior Graphic Designer
-- Oliver Byford – Lead Frontend Developer
-- Owen Jones – Senior Frontend Developer
-- Patrick Cartlidge – Frontend Developer
-- Romaric Pascal – Senior Frontend Developer
-- Trang Erskine – Senior Product Manager
+You can see the full list of team members [here on the website](https://design-system.service.gov.uk/design-system-team/).


### PR DESCRIPTION
As part of the offboarding process for Claire, I'm actioning Ollie's idea that our team page in our playbook should just link to the website page so we only have to keep one page up to date.