### PR TITLE
Remove unused email address from products page

### DIFF
--- a/source/what-we-do/index.html.md.erb
+++ b/source/what-we-do/index.html.md.erb
@@ -38,6 +38,5 @@ We maintain the GOV.UK Design System and related tools. For guidance on supporti
 [govuk-frontend-docs GitHub repository]: https://github.com/alphagov/govuk-frontend-docs
 [GOV.UK Frontend Toolkit]: https://github.com/alphagov/govuk_frontend_toolkit
 [GOV.UK Prototype Kit]: https://govuk-prototype-kit.herokuapp.com/docs
-[GOV.UK Prototype Kit Email]: govuk-prototype-kit-support@digital.cabinet-office.gov.uk
 [GOV.UK Template]: http://alphagov.github.io/govuk_template/
 [stylelint-config-gds]: https://github.com/alphagov/stylelint-config-gds


### PR DESCRIPTION
The link isn’t referred to within the page content, so this isn’t used in the HTML output.