### PR TITLE
Add common responses and support rota guides to 'Support' contents page

### DIFF
--- a/source/support/index.html.md
+++ b/source/support/index.html.md
@@ -11,5 +11,6 @@ See the “[Support Model Blueprint](https://docs.google.com/drawings/d/1ox2FK9q
 - [Support channels](./support-channels/)
 - [Daily support responsibilities](./support-responsibilites/)
 - [Communicating with users](./communicating-with-users/)
+- [Common responses](./common-responses/)
 - [How to give a new starter access to our support services](./how-to-give-a-new-starter-access-to-our-support-services/)
-
+- [How to update the support rota](./how-to-update-the-support-rota/)

--- a/source/support/index.html.md
+++ b/source/support/index.html.md
@@ -11,6 +11,6 @@ See the “[Support Model Blueprint](https://docs.google.com/drawings/d/1ox2FK9q
 - [Support channels](./support-channels/)
 - [Daily support responsibilities](./support-responsibilites/)
 - [Communicating with users](./communicating-with-users/)
-- [Common responses](./common-responses/)
+- [Common responses](https://govuk-design-system-team-docs.netlify.app/support/communicating-with-users/common-responses/)
 - [How to give a new starter access to our support services](./how-to-give-a-new-starter-access-to-our-support-services/)
 - [How to update the support rota](./how-to-update-the-support-rota/)


### PR DESCRIPTION
Making it easier to navigate to these guides