### PR TITLE
Add more comprehensive organisation colours guidance

### DIFF
--- a/source/design-and-content/designers-on-the-team.html.md
+++ b/source/design-and-content/designers-on-the-team.html.md
@@ -1,0 +1,22 @@
+---
+title: Designers on the team
+weight: 1
+---
+
+# Designers on the team
+
+## Charlotte
+
+I trained as a product designer with a bit of engineering but always preferred service design projects. GDS hired me as a motion graphic designer and illustrator, I mainly did slide decks, animations and social media assets. I’m happy to lend my hand to anything, I like to look at things in detail using grids and maths (engineering side) but I struggle with being super creative. I’m more iterative than innovative.
+
+## Chris
+
+I’m part of the team’s leadership group, so I’m involved in shaping the team’s priorities and improving how we work. If you’re not sure about how to involve design in something you’re working on, come to me! I also spend plenty of my time doing more hands-on design work, and am comfortable working across service, interaction and graphic design. I have also been at GDS and on the Design System a pretty long time, so get in touch if you’re after historical context on something – if I don’t know, I should know who does know.
+
+## Ciandelle
+
+I have a background in both service and interaction design. I prefer to work on things where I can pay close attention to detail and visualise the work as part of the larger picture. I am really confident with the prototype kit. I struggle with physical drawing and graphic design.
+
+## Mia
+
+I trained as a graphic designer but since then I’ve done a range of things, including motion graphics, product design, interaction design, illustration, publication design and exhibition design. I can draw you a logo and I can help you refine your brand. Coding in HTML and CSS are fun things I like to do when the need arises, but I’m not up on the latest frameworks. I’m generally tool agnostic, and I will always start from first principles: why does this exist, what are we trying to do, what are the words we’re using? My philosophy is: don’t try to solve a content problem with interaction design. Also, if it’s not accessible, it’s not finished.

--- a/source/design-and-content/index.html.md.erb
+++ b/source/design-and-content/index.html.md.erb
@@ -4,22 +4,3 @@ weight: 12
 ---
 
 # Design and content
-
-## Designers on the team
-
-### Charlotte
-
-I trained as a product designer with a bit of engineering but always preferred service design projects. GDS hired me as a motion graphic designer and illustrator, I mainly did slide decks, animations and social media assets. I’m happy to lend my hand to anything, I like to look at things in detail using grids and maths (engineering side) but I struggle with being super creative. I’m more iterative than innovative. 
-
-### Chris
-
-I’m part of the team’s leadership group, so I’m involved in shaping the team’s priorities and improving how we work. If you’re not sure about how to involve design in something you’re working on, come to me! I also spend plenty of my time doing more hands-on design work, and am comfortable working across service, interaction and graphic design. I have also been at GDS and on the Design System a pretty long time, so get in touch if you’re after historical context on something – if I don’t know, I should know who does know.
-
-### Ciandelle
-
-I have a background in both service and interaction design. I prefer to work on things where I can pay close attention to detail and visualise the work as part of the larger picture. I am really confident with the prototype kit. I struggle with physical drawing and graphic design. 
-
-### Mia
-
-I trained as a graphic designer but since then I’ve done a range of things, including motion graphics, product design, interaction design, illustration, publication design and exhibition design. I can draw you a logo and I can help you refine your brand. Coding in HTML and CSS are fun things I like to do when the need arises, but I’m not up on the latest frameworks. I’m generally tool agnostic, and I will always start from first principles: why does this exist, what are we trying to do, what are the words we’re using? My philosophy is: don’t try to solve a content problem with interaction design. Also, if it’s not accessible, it’s not finished.
-

--- a/source/design-and-content/organisation-colours.html.md
+++ b/source/design-and-content/organisation-colours.html.md
@@ -1,0 +1,45 @@
+---
+title: Organisation colours in GOV.UK Frontend
+weight: 2
+last_reviewed_on: 2024-10-08
+review_in: 6 months
+---
+
+# Organisation colours in GOV.UK Frontend
+
+GOV.UK Frontend includes the brand colours of various ministerial departments within the [bundled `_colours-organisations.scss` file](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss).
+
+This collection of organisations and brand colours is managed by the Design System team, but uses information originating from the HMG Identity System.
+
+## Deciding which organisations to include
+
+The organisation list should include all [ministerial departments](https://www.gov.uk/government/organisations#ministerial_departments).
+
+It should also include a few overreaching bodies that have their own brand colours and identities within the HMG Identity System, including:
+
+- HM Government
+- Civil Service
+- Prime Minister's Office, 10 Downing Street
+
+Non-ministerial departments, agencies and other public bodies don't need to be included, as these will use the same brand colour as their parent department and commonly have a website separate from GOV.UK.
+
+Exceptions can be made where the organisation uses GOV.UK as its primary web presence and has a different brand colour to its parent department (such as HM Revenue & Customs).
+
+## Determining the brand colour
+
+Brand colours are determined from a number of sources. These are:
+
+- the HMG Identity System and related assets – these are distributed via the [HMG Brand Portal](https://hmgbrand.gcs.civilservice.gov.uk/)
+- the Cabinet Office branding team, who own the HMG Identity System
+- [Design102](https://design102.co.uk/), the government's in-house design agency, who are responsible for updating the HMG Identity System
+- assets and guidelines supplied by individual organisations
+
+Where different sources provide conflicting information, the HMG Brand Portal is considered the most authoritative source and individual organisations are the least authoritative.
+
+Machinery of government changes can be chaotic times, where a lot of information and assets are being updated quickly. We might not receive updated identity guidelines until months afterwards, requiring us to rely on less reliable sources in the interim.
+
+### Creating contrast-safe alternatives
+
+Some brand colours don't provide the minimum 4.5:1 contrast ratio required by [WCAG Level AA's minimum contrast criterion](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html) when used against white. For these organisations, we additionally provide a 'contrast-safe' colour.
+
+This is done systematically by converting the brand colour to the HSL colour model and continuously reducing the lightness until the resulting colour meets the desired contrast ratio.


### PR DESCRIPTION
Adds some more detailed guidance about which organisations should be included in GOV.UK Frontend's organisation colour palette, how those colours are determined and how to create contrast-safe variants of those colours.

Written up because I realised a lot of this stuff still lived in my head or on the now-closed pull request that updated the colours. I'm not sure if there's a more fitting place for this, but it didn't seem to fit the Frontend Docs that well as it's more about a process than the technical implementation of Frontend.