### PR TITLE
Update daily support responsibilities guide

### DIFF
--- a/source/support/support-responsibilites/index.html.md
+++ b/source/support/support-responsibilites/index.html.md
@@ -1,15 +1,15 @@
 ---
 title: Daily support responsibilities
 weight: 19
-last_reviewed_on: 2023-09-04
-review_in: 3 months
+last_reviewed_on: 2024-10-17
+review_in: 6 months
 ---
 
 # Daily support responsibilities
 
 Our support hours are 10am – 4pm, Monday to Friday.
 
-The support rota is in the ‘[Design System team events]’ calendar. If you know you‘re going to be away or busy on your support day, try to find somebody to swap with on the team Slack channel. If you have an unplanned absence, let the team know on Slack and someone will cover.
+The support rota is in the ‘[Design System team events]’ calendar. If you know you‘re going to be away or busy on your support day, it is your responsibility to find somebody to swap with on the team Slack channel. If you have an unplanned absence such as illness, let the team know on Slack and Izabela will arrange cover.
 
 At the start of your support day, you should update the Slack channels with something like this message:
 
@@ -23,27 +23,16 @@ This is so it is clear to our users which responses are from the team.
 
 Remember to check Zendesk for any open tickets, especially at the start of the day. There may be tickets that came in at the end of the previous day that need responding to.
 
-If a submission to the [Community Resources] list is made whilst you are on support, it is your responsibility to review the submission against the contribution criteria. You may need to ask the contributor for further information or advise changes to the resource in order to meet the criteria, meaning the review could take longer than your support day. In this occurrence, you will continue to own the review of the submission. Ensure that you add any associated GitHub issues or pull requests to the sprint board.
+You may not be able to answer every support query you receive in a day. It's also okay to let the community answer each other's questions, however we will need to intervene if an answer is incorrect.
 
-Whilst on support, it is preferable to pause sprint work and prioritise support tasks.
+If you are handling a query which will take multiple days to resolve, leave handover notes within the 'Internal notes" feature in Zendesk.
 
-## Daily check in
+## SLAs
 
-At the end of each day you should complete the [daily check in form]. In the absence of logging support requests this will help us measure the impact of providing support.
+There are service level agreements (SLAs) in place for Zendesk and GitHub. We should respond to all new tickets, issues and PRs within 2 working days. There is not a SLA in place for Slack.
 
-[#govuk-design-system]: https://gds.slack.com/messages/CAF8JA25U
-[#govuk-design-system-xgov]: https://ukgovernmentdigital.slack.com/messages/govuk-design-system
-[Community Resources]: https://design-system.service.gov.uk/community/resources-and-tools/
-[cross government Slack]: https://ukgovernmentdigital.slack.com/
-[daily check in form]: https://docs.google.com/forms/d/e/1FAIpQLSdp1Fvypj24N1XoheRPdXbMcB784NZXaqYQkK9zGxSqhohmgg/viewform
-[Design System team events]: https://calendar.google.com/calendar/embed?src=digital.cabinet-office.gov.uk_4bkq5dftg4doh71gg8tpelgi0k%40group.calendar.google.com&ctz=Europe%2FLondon
-[govuk-design-system-issues]: https://github.com/alphagov/govuk-design-system/issues
-[govuk-design-system-prs]: https://github.com/alphagov/govuk-design-system/pulls
-[govuk-design-system-backlog-issues]: https://github.com/orgs/alphagov/projects/43
-[govuk-frontend-issues]: https://github.com/alphagov/govuk-frontend/issues
-[govuk-frontend-prs]: https://github.com/alphagov/govuk-frontend/pulls
-[guidance to invite the guest]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/information-management/using-online-tools-at-gds/use-gds-slack
-[xgov-domain-list]: https://github.com/bruntonspall/xgovslackbot/blob/ae6664437dadb2aef4c21ab97c2818f2ca5f9604/app/domains.js#L9
-[Zendesk]: https://govuk.zendesk.com/agent/dashboard
-[Zendesk-help]: https://docs.google.com/presentation/d/1VrDAuCm5qm6ULNGRco_deB7EIFf95bHFDlqG-yvLQi4/edit#slide=id.p17
+If an issue is raised on one of our repositories which you think could be high priority / urgent, let the team know on Slack. We may need to prioritise it.
 
+If a user raises a pull request (PR) on one of our repositories, let the team know via Slack. We can then decide what to do with it. Either way we should respond to the user within 2 working days.
+
+If a submission to the [Community Resources] list is made whilst you are on support, it is your responsibility to review the submission against the contribution criteria. You may need to ask the contributor for further information or advise changes to the resource in order to meet the criteria, meaning the review could take longer than your support day. In this occurrence, you will continue to own the review of the submission. Ensure that you add any associated GitHub issues or pull requests to the cycle board.


### PR DESCRIPTION
- remove outdated information
- add information on SLAs
- add information on handover notes in Zendesk