### PR TITLE
Update support channels guide

### DIFF
--- a/source/support/support-channels/index.html.md
+++ b/source/support/support-channels/index.html.md
@@ -51,26 +51,10 @@ Create a team calendar event for checking the day after the account closure date
 
 - govuk-frontend [issues][govuk-frontend-issues] and [pull requests][govuk-frontend-prs]
 - govuk-design-system [issues][govuk-design-system-issues] and [pull requests][govuk-design-system-prs]
-- govuk-design-system-backlog [issues][govuk-design-system-backlog-issues]
 
-Whilst on daily support, any new pull requests or issues raised that day should be reviewed.
+Whilst on daily support, any new pull requests or issues raised that day should be shared with the team.
 
-All new pull requests should be added to the sprint board. At the next stand up the team will identify reviewers.
-
-For new issues you should:
-
-1. Flag in the team Slack channel if you think the issue meets the below high-priority criteria and add `high-priority` label:
-  - A bug which renders something unusable
-  - A WCAG failure
-  - An issue which has been raised by users on more than 5 occasions (tracked by adding comments to the GitHub issue each time it appears on support)
-2. The `submitted-by-user` label should be added to any issues opened on behalf of a user. This will help us further down the line when we do an analysis.
-3. Add estimate labels
-	- `🕔 hours`: a well understood issue which we expect to take less than a day to resolve. Could be something that community could be involved in (eg. first timer issues).
-  - `🕔 days`: a few unknowns, but we roughly know what’s involved. We’d expect it to take less than a week to resolve. May be a good thing to pair on.
-  - `🕔 weeks`: This is complicated and will require a lot of effort from the team, taking more than a week to resolve. May need breaking down into smaller pieces of work.
-4. Add other appropriate labels such as related components and patterns or themes
-
-If you need help from the team to triage an issue, use the team Slack channel to ask.
+All new pull requests should be added to the cycle board.
 
 ### How to see new issues, PRs and comments on our repos
 
@@ -84,7 +68,6 @@ Now select the repositories you want to “watch”. This should be:
 
 - [alphagov/govuk-design-system]
 - [alphagov/govuk-frontend]
-- [alphagov/govuk-design-system-backlog]
 
 You can watch each of these repositories by selecting the ‘Watch’ drop-down in the top right and selecting ‘All activity’.
 
@@ -93,24 +76,6 @@ To get the notifications view, click on [this link][github-notifications-view]
 It should look like this:
 
 ![Github notifications view](../assets/images/github-notifications-view.png)
-
-### Recording new queries relating to an existing issue 
-
-If you receive a query regarding an issue which already exists on one of our repositories, add a comment to that issue noting that this has appeared on support that day. When we reach 5 instances of this, add the “high priority” label and flag in the team Slack channel.
-
-### Responding to Community Backlog issues and comments
-
-- Make sure you are responding to comments that need our team’s answer. 
-- Keep an eye on the [latest comments]
-- To have an overview, check the [project board][govuk-design-system-backlog-issues]
-
-### Adding newly raised issues to the board
-
-We ask contributors to [get in touch with us when they raise a new issue][raise-issue] in the backlog. 
-
-This is so we can help them:
-- briefly review the issue to make sure it’s appropriate
-- add it to the [GitHub projects ‘list view’][govuk-design-system-backlog-issues-list] of the backlog
 
 ## Email
 
@@ -142,34 +107,3 @@ Once the user has clarified which topics they want to hear about you can add the
 4. Go back to the ticket and let the user know that they’ve been added:
 
 > We've added you manually to our mailing list with the requested settings. Please feel free to contact us in future if you require further assistance.
-
-## Analysing our support requests
-
-On a monthly basis, we will pull all the tickets from GitHub repos, slack and zendesk into the [support log spreadsheet]. We will be able to search and filter by time, channel and tag. We will use this data to identify areas the users need the most support and define epics/stories from that or plan further research. 
-
-We also hold bi-weekly sessions to give tags to Slack messages. 
-
-[#govuk-design-system]: https://gds.slack.com/messages/CAF8JA25U
-[#govuk-design-system-xgov]: https://ukgovernmentdigital.slack.com/messages/govuk-design-system
-[alphagov/govuk-design-system]: https://github.com/alphagov/govuk-design-system
-[alphagov/govuk-frontend]: https://github.com/alphagov/govuk-frontend
-[alphagov/govuk-design-system-backlog]: https://github.com/alphagov/govuk-design-system-backlog
-[cross government Slack]: https://ukgovernmentdigital.slack.com/
-[github-notifications-view]: https://github.com/notifications?query=repo%3Aalphagov%2Fgovuk-design-system-backlog+repo%3Aalphagov%2Fgovuk-design-system+repo%3Aalphagov%2Fgovuk-frontend+
-[govuk-design-system-issues]: https://github.com/alphagov/govuk-design-system/issues
-[govuk-design-system-prs]: https://github.com/alphagov/govuk-design-system/pulls
-[govuk-design-system-backlog-issues]: https://github.com/orgs/alphagov/projects/43
-[govuk-design-system-backlog-issues-list]: https://github.com/orgs/alphagov/projects/43/views/2
-[govuk-frontend-issues]: https://github.com/alphagov/govuk-frontend/issues
-[govuk-frontend-prs]: https://github.com/alphagov/govuk-frontend/pulls
-[#ask-an-admin]: https://ukgovernmentdigital.slack.com/archives/C039WM501EK
-[guidance-to-invite-the-guest]: https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/information-management/using-online-tools-at-gds/use-gds-slack
-[latest comments]: https://github.com/alphagov/govuk-design-system-backlog/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
-[mailchimp]: https://login.mailchimp.com/
-[raise-issue]: https://design-system.service.gov.uk/community/propose-a-component-or-pattern/#2-raise-an-issue
-[support log spreadsheet]: https://docs.google.com/document/d/1G-TN0uXeKchwhHZnmPveX5YteXi3uSl0Rf5vtg-J5l4/edit?usp=sharing
-[support model blueprint]: https://docs.google.com/drawings/d/1ox2FK9q6GRyY_zvhSuFIOT9-a6Wd-R4-kP8OlrzVCvk/edit
-[xgov-domain-list]: https://github.com/bruntonspall/xgovslackbot/blob/ae6664437dadb2aef4c21ab97c2818f2ca5f9604/app/domains.js#L9
-[Zendesk]: https://govuk.zendesk.com/agent/dashboard
-[Zendesk-help]: https://docs.google.com/presentation/d/1VrDAuCm5qm6ULNGRco_deB7EIFf95bHFDlqG-yvLQi4/edit#slide=id.p17
-


### PR DESCRIPTION
- remove references to supporting the community backlog for now
- remove references to support ticket analysis
- simply what to do with PRs and issues