### PR TITLE
Add draft for guidance on how to manage Slack channels for briefs

### DIFF
--- a/source/guides/how-to-manage-slack-channels-for-briefs.html.md
+++ b/source/guides/how-to-manage-slack-channels-for-briefs.html.md
@@ -1,0 +1,45 @@
+How to manage Slack channels for briefs
+===
+
+Communication around each briefs should happen in dedicated Slack channels. This provides a specific space for each brief, avoiding our main channel to become a mesh of messages for different pieces of work. 
+
+By default, these channels should be public, not only so we work in the open within GDS, but to facilitate access to the discussions for the whole team without needing an explicit invite. Specific pieces of work may require a little less openness (sensitive topics or something we can't disclose yet), in which case we'll create private channels.
+
+## Reusing channels
+
+If a brief is a continuation of a previous piece of work for which a channel already exists, please carry-on in the existing channel, inviting people to leave the channel if they want to protect their attention. This will help looking back at previous discussions for that brief.
+
+If this existing channel was archived, you can [unarchive the channel](https://slack.com/intl/en-gb/help/articles/213185307-Archive-or-delete-a-channel#h_01FFR2DKWZQZ9BHDMEHBXTFQAW) to start using it again.
+
+## Creating new channels
+
+If you need to [create a new channel](https://slack.com/intl/en-gb/help/articles/201402297-Create-a-channel):
+- make sure its name is prefixed by `ds-` so people in the team can easily find our channels. If you forget this when creating the channel, you can [rename a channel after it's created](https://slack.com/intl/en-gb/help/articles/201654073-Rename-a-channel)
+- make sure to add at least [one other person as channel manager](https://slack.com/intl/en-gb/help/articles/8328303095443-Understand-Channel-Managers-in-Slack), this reduce the risks of us having to reach for Slack admins if we need to make manager-level updates to the channel.
+- if the channel is private, make sure to [invite](https://slack.com/intl/en-gb/help/articles/201980108-Add-people-to-a-channel) the team leads to it for awareness.
+
+## Using channels tabs to keep track of important things
+
+Within a channel, Slack allows you to create extra [tabs](https://slack.com/intl/en-gb/help/articles/32562841868307-Edit-tabs-in-a-channel-or-DM) alongside the thread of messages.
+
+Particularly, adding a ['Canvas'](https://slack.com/intl/en-gb/help/articles/203950418-Use-a-canvas-in-Slack#a-channel-or-dm-canvas) or ['Bookmarks'](https://slack.com/intl/en-gb/help/articles/205239997-Pin-messages-and-bookmark-links#manage-bookmarks) can be a great way to keep track of important links for the brief, such as:
+
+- The GitHub issue of the brief
+- The folder on Google Drive in which to store documents related to the brief
+- A decision log, if your squad is using one
+
+## Archiving channels
+
+Once the piece of work that the channel is related to is completed (could be after a single brief, or multiple ones, possibly with a span of inactivity in the middle), make sure to [archive the channel](https://slack.com/intl/en-gb/help/articles/213185307-Archive-or-delete-a-channel#h_01J9758G8FB9Z27BD4JV1B1DPB).
+This will reduce the noise in the overall list of channels at GDS, while still retaining all the messages in the channel and allowing to search its history if necessary. 
+
+You can [unarchive a channel](https://slack.com/intl/en-gb/help/articles/213185307-Archive-or-delete-a-channel#h_01FFR2DKWZQZ9BHDMEHBXTFQAW) if you archived it by mistake or need to revive an old one.
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Starter for 10 on a guide to manage Slack channels during briefs. Up for any additions and content edits.

It includes information about:
- creating channels for each brief
- using tabs to store links to informations about the brief
- archiving channels after a brief (we don't really do that, but that would keep things tidy)

I think it could probably have an extra section about:
- preferring open communications in your squad's channel to DMs, as it allows other people to respond
- communication not being restricted to your squad's channel: if you have a question/notification for the rest of the team or need some help because you're missing this or that expertise, posting on the team channel (again, preferably to DMs) is a-ok.