### PR TITLE
Create how-a-delivery-manager-will-support-a-squad

### DIFF
--- a/source/delivery-management/how-a-delivery-manager-will-support-a-squad.html.md
+++ b/source/delivery-management/how-a-delivery-manager-will-support-a-squad.html.md
@@ -1,16 +1,18 @@
-how-a-delivery-manager-will-support-a-squad.html.md
-
 ---
 title: how a delivery manager will support a squad
 weight: 5
 ---
+
 # Delivery manager role
 A delivery manager is accountable for the delivery of squad work.
 You can read more about how they do this in the [Government Digital and Data Profession Capability Framework](https://ddat-capability-framework.service.gov.uk/role/delivery-manager).
+
 ## Working with a squad
 
 ### Setting up a cycle
+
 The delivery manager will be responsible for:
+
 - reviewing the cycle brief written by the team leads and ensuring yourself and the entire squad understands the problem or goal, working closely with product managers manage scope
 - ensuring sub-issues are written and attached to the brief on GitHub (either by writing them, pair writing or delegating to a squad member)
 - establish clear ownership of work between squad members, to prevent silos and misunderstandings
@@ -18,7 +20,9 @@ The delivery manager will be responsible for:
 - modelling good GitHub hygiene and making sure the squad to visualise their work through fully completed issue descriptions, accurate done whens, labels, milestones and other tracking mechanisms available
 
 ### Delivering the work
+
 The delivery manager will be responsible for:
+
 - making sure the squad is working on the deliverables of the brief, maintaining focus and avoiding unplanned work or scope creep
 - applying healthy pressure to ensure squads are working to meet a deadline
 - identifying and resolving blockers and issues such as decision making, uncertainty over priorities, and arranging review / input from specific disciplines
@@ -27,7 +31,9 @@ The delivery manager will be responsible for:
 - ensuring all decisions which can be resolved by a squad are before a cycle ends, and ensuring the resulting actions are recorded in GitHub
 
 ### Wrapping up a cycle
+
 The delivery manager will be responsible for:
+
 - closing completed briefs and sub-issues when a cycle is complete, and transferring any outstanding issues to a new brief or creating a small story 
 - communicating to the Lead Delivery Manager what has been delivered at the end of a cycle, and what needs to carry over
 - following up on pain points expressed in retrospectives, driving iterations to ways of working

--- a/source/delivery-management/how-a-delivery-manager-will-support-a-squad.html.md
+++ b/source/delivery-management/how-a-delivery-manager-will-support-a-squad.html.md
@@ -1,0 +1,33 @@
+how-a-delivery-manager-will-support-a-squad.html.md
+
+---
+title: how a delivery manager will support a squad
+weight: 5
+---
+# Delivery manager role
+A delivery manager is accountable for the delivery of squad work.
+You can read more about how they do this in the [Government Digital and Data Profession Capability Framework](https://ddat-capability-framework.service.gov.uk/role/delivery-manager).
+## Working with a squad
+
+### Setting up a cycle
+The delivery manager will be responsible for:
+- reviewing the cycle brief written by the team leads and ensuring yourself and the entire squad understands the problem or goal, working closely with product managers manage scope
+- ensuring sub-issues are written and attached to the brief on GitHub (either by writing them, pair writing or delegating to a squad member)
+- establish clear ownership of work between squad members, to prevent silos and misunderstandings
+- deciding on the best method of delivery for the squad make up and context in any given cycle, including deciding the frequency of ceremonies, and how work is sequenced
+- modelling good GitHub hygiene and making sure the squad to visualise their work through fully completed issue descriptions, accurate done whens, labels, milestones and other tracking mechanisms available
+
+### Delivering the work
+The delivery manager will be responsible for:
+- making sure the squad is working on the deliverables of the brief, maintaining focus and avoiding unplanned work or scope creep
+- applying healthy pressure to ensure squads are working to meet a deadline
+- identifying and resolving blockers and issues such as decision making, uncertainty over priorities, and arranging review / input from specific disciplines
+- seeking and providing clarity when there is uncertainty
+- monitoring risks to delivery and applying mitigations ahead of a risk materialising, escalating to the Lead Delivery Manager if it cannot be resolved within the team  
+- ensuring all decisions which can be resolved by a squad are before a cycle ends, and ensuring the resulting actions are recorded in GitHub
+
+### Wrapping up a cycle
+The delivery manager will be responsible for:
+- closing completed briefs and sub-issues when a cycle is complete, and transferring any outstanding issues to a new brief or creating a small story 
+- communicating to the Lead Delivery Manager what has been delivered at the end of a cycle, and what needs to carry over
+- following up on pain points expressed in retrospectives, driving iterations to ways of working

--- a/source/delivery-management/index.html.md.erb
+++ b/source/delivery-management/index.html.md.erb
@@ -4,4 +4,6 @@ weight: 11
 ---
 
 # Delivery management
+
+- [How a delivery manager will support a squad](./how-a-delivery-manager-will-support-a-squad/)
 - [Roles and responsibilities](./delivery-manager-roles-and-responsibilities/)


### PR DESCRIPTION
Adding additional folder in the delivery management guide around how delivery manager will support squads.