### PR TITLE
(Re)enable search 🔍 

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -14,7 +14,7 @@ header_links:
   Sprint board: https://github.com/orgs/alphagov/projects/53
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
-enable_search: false
+enable_search: true
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:


### PR DESCRIPTION
Search was disabled in d93fa6d, but there's no rationale recorded for having done so…

Given how useful search can be (especially given the organic information architecture of the docs repo…), re-enable it.